### PR TITLE
Bugfix on TypeError: can only concatenate str (not "bytes") to str

### DIFF
--- a/dup.py
+++ b/dup.py
@@ -13,7 +13,7 @@ def calc_file_hash(filename, size):
         f = open(filename, 'rb')
         md51 = hashlib.md5(f.read(size10M)).hexdigest()
         f.seek(size - size10M)
-        return hashlib.md5(md51 + f.read(size10M)).hexdigest()
+        return hashlib.md5(md51.encode() + f.read(size10M)).hexdigest()
 
 
 def create_db(name):


### PR DESCRIPTION
修复以下bug：
Traceback (most recent call last):
  File "synologytools/dup.py", line 126, in <module>
    run(os.path.abspath(sys.argv[1]), sys.argv[2].lower())
  File "synologytools/dup.py", line 68, in run
    calc_file_hash(os.path.join(row[1], row[2]), row[3])), row[0]))
  File "synologytools/dup.py", line 16, in calc_file_hash
    return hashlib.md5(md51 + f.read(size10M)).hexdigest()
TypeError: can only concatenate str (not "bytes") to str